### PR TITLE
Configured ESLint for strict TypeScript config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,9 +5,9 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "src/components/ui/**", "scripts/**", "src/hooks/use-toast.ts", "src/hooks/use-mobile.tsx"] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [js.configs.recommended, ...tseslint.configs.strict],
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
@@ -20,7 +20,10 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
-      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/explicit-function-return-type": ["error", { allowExpressions: true }],
+      "@typescript-eslint/consistent-type-imports": ["error", { prefer: "type-imports" }],
     },
   },
 );

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "build:dev": "vite build --mode development",
+    "build": "eslint . && vite build",
+    "build:dev": "eslint . && vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",

--- a/src/components/BatteryIndicator.tsx
+++ b/src/components/BatteryIndicator.tsx
@@ -13,19 +13,19 @@ interface BatteryIndicatorProps {
  * @returns The rendered Battery Indicator component.
  */
 export function BatteryIndicator({ percentage, isCharging = false }: BatteryIndicatorProps): JSX.Element {
-  const getBatteryColor = () => {
+  const getBatteryColor = (): string => {
     if (percentage <= 20) return "bg-destructive";
     if (percentage <= 50) return "bg-warning";
     return "bg-success";
   };
 
-  const getBatteryTextColor = () => {
+  const getBatteryTextColor = (): string => {
     if (percentage <= 20) return "text-destructive";
     if (percentage <= 50) return "text-warning";
     return "text-success";
   };
 
-  const getBatteryIcon = () => {
+  const getBatteryIcon = (): typeof BatteryCharging => {
     if (isCharging) return BatteryCharging;
     if (percentage <= 20) return BatteryLow;
     if (percentage <= 50) return BatteryMedium;

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,4 +1,5 @@
-import { NavLink as RouterNavLink, NavLinkProps } from "react-router-dom";
+import { NavLink as RouterNavLink} from "react-router-dom";
+import type { NavLinkProps  } from "react-router-dom";
 import { forwardRef } from "react";
 import { cn } from "@/lib/utils";
 

--- a/src/features/dashboard/hooks/useDashboardRobotViewState.ts
+++ b/src/features/dashboard/hooks/useDashboardRobotViewState.ts
@@ -11,7 +11,7 @@ export function useDashboardRobotViewState({
   robotStatus,
   cleaningProgress,
   maxProgress,
-}: Params) {
+}: Params): { cleaningProgress: number; isCharging: boolean; isCleaning: boolean; isControlDisabled: boolean } {
   return useMemo(
     () => ({
       cleaningProgress: Math.min(cleaningProgress, maxProgress),

--- a/src/features/dashboard/services/taskService.ts
+++ b/src/features/dashboard/services/taskService.ts
@@ -12,7 +12,7 @@ function startTimedTask({
   successDelayMs,
   startMessage,
   successMessage,
-}: StartTaskParams) {
+}: StartTaskParams): void {
   toast.info(startMessage);
   execute();
   setTimeout(() => toast.success(successMessage), successDelayMs);

--- a/src/features/dashboard/useDashboardController.ts
+++ b/src/features/dashboard/useDashboardController.ts
@@ -3,10 +3,24 @@ import { getConfig } from "@/lib/config";
 import { useRobotStore } from "@/store/robotStore";
 import { useDashboardTaskManagement } from "@/features/dashboard/useDashboardTaskManagement";
 import { useDashboardRobotViewState } from "@/features/dashboard/hooks/useDashboardRobotViewState";
+import type { DeployState, RobotStatus } from "@/lib/constants";
+
+interface DashboardController {
+  deployState: DeployState;
+  robotStatus: RobotStatus;
+  batteryLevel: number;
+  currentLocation: string;
+  cleaningProgress: number;
+  isCharging: boolean;
+  isCleaning: boolean;
+  isControlDisabled: boolean;
+  handleDeploy: () => Promise<void>;
+  handleStop: () => Promise<void>;
+}
 
 const config = getConfig();
 
-export function useDashboardController() {
+export function useDashboardController(): DashboardController {
   const {
     deployState,
     robotStatus,

--- a/src/features/dashboard/useDashboardTaskManagement.ts
+++ b/src/features/dashboard/useDashboardTaskManagement.ts
@@ -8,9 +8,14 @@ interface UseDashboardTaskManagementParams {
   updateStatus: (patch: Partial<RobotState>) => void;
 }
 
+interface DashboardTaskManagement {
+  handleDeploy: () => Promise<void>;
+  handleStop: () => Promise<void>;
+}
+
 export function useDashboardTaskManagement({
   updateStatus,
-}: UseDashboardTaskManagementParams) {
+}: UseDashboardTaskManagementParams): DashboardTaskManagement {
   const handleDeploy = useCallback(async () => {
     toast.info("Initializing robot systems...");
     updateStatus({

--- a/src/hooks/useRobotSimulation.ts
+++ b/src/hooks/useRobotSimulation.ts
@@ -7,7 +7,7 @@ import { getRobotSimulationStep } from '@/features/robot/robotSimulationStep';
 
 const config = getConfig();
 
-export function useRobotSimulation() {
+export function useRobotSimulation(): void {
   const { robotStatus, batteryLevel, cleaningProgress, updateStatus } = useRobotStore();
   const batteryLevelRef = useRef<number>(batteryLevel);
   const cleaningProgressRef = useRef<number>(cleaningProgress);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-export function cn(...inputs: ClassValue[]) {
+export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,6 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(<App />);
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Root element not found");
+createRoot(rootElement).render(<App />);

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -5,7 +5,7 @@ import { useEffect } from "react";
  * Not Found component.
  * @returns The rendered Not Found component.
  */
-const NotFound = () => {
+const NotFound = (): JSX.Element => {
   const location = useLocation();
 
   useEffect(() => {


### PR DESCRIPTION
### VIBE REPORT (FIXES #39):

#### 1. Target Selected
`eslint.config.js` was selected because it's just tooling. Changes here would have no impact on the deployed app or runtime behavior. If any errors surfaced with this refactor, the worst outcome would be a broken lint command.

#### 2. Verification Event
The AI suggested the following line of code `{ ignores: ["dist"] }`. However, when running ESLint in the command line, missing return type errors kept coming from auto-generated Shadcn UI components that silently delete return type annotations. I manually changed the line to `{ ignores: ["dist", "src/components/ui/**"] }` to exclude auto-generated UI components from the ESLint rules. After prompting the AI about this change, it suggested changing the line to `{ ignores: ["dist", "src/components/ui/**", "scripts/**", "src/hooks/use-toast.ts", "src/hooks/use-mobile.tsx"] }` to exclude script files and Shadcn UI auto-generated hooks. I also changed the build script from `"build": "vite build"` to `"build": "eslint . && vite build"` to ensure that ESLint rules have to be met to allow a build.

#### 3. Trust Boundary Established
Before the refactor, TypeScript rule violations could exist in the codebase silently. Now:

- ESLint enforces these rules on every file in src/ (excluding auto-generated shadcn UI components and hooks)
- ESLint is chained into npm run build via eslint . && vite build, meaning a violation prevents a production build
- Type regressions are caught before they ship

#### 4. Evidence of Execution
ESLint rule configuration:

<img width="759" height="645" alt="image" src="https://github.com/user-attachments/assets/2bbda6aa-5791-469c-88f5-feb42ff2cdc2" />

Project Build:

<img width="761" height="341" alt="image" src="https://github.com/user-attachments/assets/877f83ef-d9da-4a73-b7d0-3953e82d01c7" />

A successful build means no violation of ESLint rules.